### PR TITLE
Publish keys for STRICT mode configuration.

### DIFF
--- a/lib/Devel/StrictMode.pm
+++ b/lib/Devel/StrictMode.pm
@@ -13,15 +13,16 @@ our @EXPORT    = qw( STRICT );
 our @EXPORT_OK = qw( LAX );
 
 BEGIN {
+	our @KEYS = qw(
+		EXTENDED_TESTING
+		AUTHOR_TESTING
+		RELEASE_TESTING
+		PERL_STRICT
+	);
+
 	my $strict = 0;
-	$ENV{$_} && $strict++
-		for qw(
-			EXTENDED_TESTING
-			AUTHOR_TESTING
-			RELEASE_TESTING
-			PERL_STRICT
-		);
-	
+	$ENV{$_} && $strict++ for @KEYS;
+
 	eval "
 		sub STRICT () { !! $strict }
 		sub LAX    () {  ! $strict }

--- a/t/02lax.t
+++ b/t/02lax.t
@@ -20,10 +20,8 @@ the same terms as the Perl 5 programming language system itself.
 =cut
 
 BEGIN {
-	$ENV{EXTENDED_TESTING} =
-	$ENV{RELEASE_TESTING} =
-	$ENV{AUTHOR_TESTING} =
-	$ENV{PERL_STRICT} = 0;
+	require Devel::StrictMode;
+	$ENV{$_} = 0 for @Devel::StrictMode::KEYS;
 };
 
 use strict;

--- a/t/03require.t
+++ b/t/03require.t
@@ -1,0 +1,19 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test that Devel::StrictMode works with `require`.
+In this case, this module imports nothing.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+require Devel::StrictMode;
+
+ok !__PACKAGE__->can('STRICT');
+ok !__PACKAGE__->can('LAX');


### PR DESCRIPTION
This update provides to reduce hard-coded values like the folowing:

> BEGIN {
>     # Disable STRICT mode. SEE ALSO: Devel::StrictMode
>     $ENV{EXTENDED_TESTING} = 0;
>     $ENV{AUTHOR_TESTING}   = 0;
>     $ENV{RELEASE_TESTING}  = 0;
>     $ENV{PERL_STRICT}      = 0;
> }
>
> -- https://github.com/kfly8/Syntax-Keyword-Assert/blob/1752a71a833437933e22853336a425bb724a8800/t/02_assert_with_strict_disabled.t#L3-L9